### PR TITLE
[ fix #66 ] README: Add constraint Cabal>=1.24 to setup-depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ section in your `.cabal` file. For example:
 ```
 custom-setup
  setup-depends:
-   base >= 4 && <5,
-   Cabal,
-   cabal-doctest >= 1 && <1.1
+   base          >= 4 && < 5,
+   Cabal         >= 1.24,
+   cabal-doctest >= 1.0.8 && < 1.1
 ```
 
 /Note:/ `Cabal` dependency is needed because of

--- a/simple-example/simple-example.cabal
+++ b/simple-example/simple-example.cabal
@@ -19,7 +19,7 @@ tested-with:   GHC >=7.10 && <8.8 || ==8.8.3 || ==8.10.1
 custom-setup
   setup-depends:
       base
-    , Cabal
+    , Cabal          >=1.24
     , cabal-doctest  >=1.0.8 && <1.1
 
 library


### PR DESCRIPTION
[ fix #66 ] README: Add constraint Cabal>=1.24 to setup-depends

Also harmonize setup-depends between README.md and simple-example.cabal

This constraint seems to be a good default suggestion (fixed a build for me).
Take this PR with a grain of salt, though... I am just a user.