### PR TITLE
Release 1.0.9

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,15 +1,16 @@
+# 1.0.9 -- 2021-11-04
 
-* Support GHC-9.2, base-4.16 and, Cabal-3.6
+* Support `GHC-9.2`, `base-4.16`, and `Cabal-3.6` (thanks Alistair Burrowes).
 
 # 1.0.8 -- 2019-10-02
 
-* Pass `-package-env=-` when compiler supports it
-* Amend examples to `unsetEnv "GHC_ENVIRONMENT"`
+* Pass `-package-env=-` when compiler supports it.
+* Amend examples to `unsetEnv "GHC_ENVIRONMENT"`.
 
 # 1.0.7 -- 2019-08-26
 
-* Make `Distribution.Extra.Doctest` `-Wall`-clean
-* Support GHC-8.8, base-4.13, and Cabal-3.0
+* Make `Distribution.Extra.Doctest` `-Wall`-clean.
+* Support `GHC-8.8`, `base-4.13`, and `Cabal-3.0`.
 
 # 1.0.6 -- 2018-01-28
 
@@ -29,23 +30,19 @@
 
 # 1.0.3 -- 2017-11-02
 
-* Add an explicit `Prelude` import to `Build_doctests`
+* Add an explicit `Prelude` import to `Build_doctests`.
 
 # 1.0.2 -- 2017-05-16
 
 * Add `defaultMainAutoconfWithDoctests` and `addDoctestsUserHook`.
-
 * Add support for `.hsc` and other preprocessed files
-  ([#8](https://github.com/phadej/cabal-doctest/issues/8))
-
+  ([#8](https://github.com/phadej/cabal-doctest/issues/8)).
 * Add support for `x-doctest-source-dirs` and `x-doctest-modules`.
 
 # 1.0.1 -- 2017-05-05
 
-* Add support for `x-doctest-options` cabal-file field
-
-* Proper support for GHC-8.2.1 & Cabal-2.0.0.0
-
+* Add support for `x-doctest-options` cabal-file field.
+* Proper support for `GHC-8.2.1` and `Cabal-2.0.0.0`.
 * Add support to `default-extensions` in library.
 
 # 1  -- 2017-01-31

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# 1.0.9 -- 2021-11-04
+# 1.0.9 -- 2021-11-07
 
 * Support `GHC-9.2`, `base-4.16`, and `Cabal-3.6` (thanks Alistair Burrowes).
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 cabal-doctest
 =============
 
-[![Hackage](https://img.shields.io/hackage/v/cabal-doctest.svg)](https://hackage.haskell.org/package/cabal-doctest) [![Build Status](https://travis-ci.org/phadej/cabal-doctest.svg?branch=master)](https://travis-ci.org/phadej/cabal-doctest)
+[![Hackage](https://img.shields.io/hackage/v/cabal-doctest.svg)](https://hackage.haskell.org/package/cabal-doctest) [![Haskell-CI](https://github.com/haskellari/cabal-doctest/actions/workflows/haskell-ci.yml/badge.svg?branch=master)](https://github.com/haskellari/cabal-doctest/actions/workflows/haskell-ci.yml)
 
 A `Setup.hs` helper for running `doctests`.
 
 Simple example
 --------------
 
-For most use cases—a `.cabal` file with a single library containing
-doctests—adapting the simple example located
-[here](https://github.com/phadej/cabal-doctest/tree/master/simple-example)
-will be sufficient. (Note that this example requires `Cabal-1.24` or later, but
-you can relax this bound safely, although running doctests won't be supported
-on versions of `Cabal` older than 1.24.)
+For the typical use case, namely a `.cabal` file with a single library containing
+doctests, adapting the [simple example](https://github.com/phadej/cabal-doctest/tree/master/simple-example)
+will be sufficient.
 
 To use this library in your `Setup.hs`, you should specify a `custom-setup`
 section in your `.cabal` file. For example:
@@ -26,8 +23,8 @@ custom-setup
    cabal-doctest >= 1 && <1.1
 ```
 
-/Note:/ `Cabal` dependency is needed because of
-[Cabal/GH-4288](https://github.com/haskell/cabal/issues/4288) bug.
+_Note:_ The `Cabal` dependency is only needed for `cabal-install < 2.4`
+(see issue [haskell/cabal#4288](https://github.com/haskell/cabal/issues/4288)).
 
 You'll also need to specify `build-type: Custom` at the top of the `.cabal`
 file. Now put this into your `Setup.hs` file:
@@ -73,8 +70,8 @@ Example with multiple .cabal components
 `cabal-doctest` also supports more exotic use cases where a `.cabal` file
 contains more components with doctests than just the main library, including:
 
-* Doctests in executables
-* Doctests in Internal libraries (if using `Cabal-2.0` or later)
+* doctests in executables,
+* doctests in internal libraries (if using `Cabal-2.0` or later).
 
 Unlike the simple example shown above, these examples involve _named_
 components. You don't need to change the `Setup.hs` script to support
@@ -82,12 +79,12 @@ this use case. However, in this scenario `Build_doctests` will generate extra
 copies of the `flags`, `pkgs`, and `module_sources` values for each additional
 named component.
 
-Simplest approach is to use `x-doctest-components` field, for example
+Simplest approach is to use `x-doctest-components` field, for example:
 ```
 x-doctest-components: lib lib:internal exe:example
 ```
 
-In that case, the testdrive is general:
+In that case, the test driver is generally:
 
 ```haskell
 module Main where
@@ -107,7 +104,7 @@ main = for_ components $ \(Component name flags pkgs sources) -> do
     doctest args
 ```
 
-There's also a more explicit approach: if you have an executable named `foo`,
+There is also a more explicit approach: if you have an executable named `foo`,
 then separate values named `flags_exe_foo`, `pkgs_exe_foo`, and `module_sources_exe_foo` will
 be generated in `Build_doctests`. If the name has hyphens in it
 (e.g., `my-exe`), then `cabal-doctest` will convert those hyphens to
@@ -193,10 +190,6 @@ Notes
   you have to use `explicit-setup-deps` setting in your `stack.yaml`.
   ([stack/GH-2094](https://github.com/commercialhaskell/stack/issues/2094))
 
-* There is [an issue in the Cabal issue tracker](https://github.com/haskell/cabal/issues/2327)
-  about adding `cabal doctest` command. After that command is implemented,
-  this library will be deprecated.
-
 * You can use `x-doctest-options` field in `test-suite doctests` to
   pass additional flags to the `doctest`.
 
@@ -207,7 +200,7 @@ Notes
   might fail with weird errors (ambiguous module errors). Workaround is
   to move sources under `src/` or some non-top-level directory.
 
-* `extensions:` field isn't supported. Upgrade your `.cabal` file to use at least
+* The `extensions:` field isn't supported. Upgrade your `.cabal` file to use at least
   `cabal-version: >= 1.10` and use `default-extensions` or `other-extensions`.
 
 * If you use QuickCheck properties (`prop>`) in your doctests,

--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -1,18 +1,16 @@
 name:               cabal-doctest
 version:            1.0.9
-synopsis:           A Setup.hs helper for doctests running
+synopsis:           A Setup.hs helper for running doctests
 description:
-  Currently (beginning of 2017), there isn't @cabal doctest@
-  command. Yet, to properly work doctest needs plenty of configuration.
-  This library provides the common bits for writing custom Setup.hs
-  See <https://github.com/haskell/cabal/issues/2327 Cabal/2327> for the progress
-  of @cabal doctest@, i.e. whether this library is obsolete.
+  As of now (end of 2021), there isn't @cabal doctest@
+  command. Yet, to properly work, @doctest@ needs plenty of configuration.
+  This library provides the common bits for writing a custom @Setup.hs@.
 
-homepage:           https://github.com/phadej/cabal-doctest
+homepage:           https://github.com/haskellari/cabal-doctest
 license:            BSD3
 license-file:       LICENSE
 author:             Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Andreas Abel
 copyright:          (c) 2017 Oleg Grenrus
 category:           Distribution
 build-type:         Simple
@@ -39,7 +37,7 @@ tested-with:
 
 source-repository head
   type:     git
-  location: https://github.com/phadej/cabal-doctest
+  location: https://github.com/haskellari/cabal-doctest
 
 library
   exposed-modules:  Distribution.Extra.Doctest


### PR DESCRIPTION
I am planning to release 1.0.9 now, even though `doctest` isn't up for GHC 9.2 yet.
The reason: `cabal-doctest` is already needed to _set a package up_ that wants to run doctests.  So it blocks installation of libraries and executables, not only of testsuites. See e.g.:
- https://github.com/snoyberg/xml/issues/170

This PR makes only textual changes to the package documentation.
Candidate at: https://hackage.haskell.org/package/cabal-doctest-1.0.9/candidate